### PR TITLE
Fix Chapter07/pretty_print_on_the_fly.cpp

### DIFF
--- a/Chapter07/pretty_print_on_the_fly.cpp
+++ b/Chapter07/pretty_print_on_the_fly.cpp
@@ -4,11 +4,14 @@
 using namespace std;
 
 class format_guard {
-    decltype(cout.flags()) f {cout.flags()};
+    ostream& _os;
+    ios::fmtflags _f;
 
 public:
-    ~format_guard() { cout.flags(f); }
+    explicit format_guard(ostream& os = cout) : _os(os), _f(os.flags()) {}
+    ~format_guard() { _os.flags(_f); }
 };
+
 
 template <typename T>
 struct scientific_type {
@@ -19,7 +22,7 @@ struct scientific_type {
 
 template <typename T>
 ostream& operator<<(ostream &os, const scientific_type<T> &w) {
-    format_guard _;
+    format_guard _{os};
     os << scientific << uppercase << showpos;
     return os << w.value;
 }

--- a/Chapter07/pretty_print_on_the_fly.cpp
+++ b/Chapter07/pretty_print_on_the_fly.cpp
@@ -8,7 +8,7 @@ class format_guard {
     ios::fmtflags f;
 
 public:
-    explicit format_guard(ostream& os = cout) : os(os), f(os.flags()) {}
+    explicit format_guard(ostream &guarded_stream = cout) : os(guarded_stream), f(os.flags()) {}
     ~format_guard() { os.flags(f); }
 };
 

--- a/Chapter07/pretty_print_on_the_fly.cpp
+++ b/Chapter07/pretty_print_on_the_fly.cpp
@@ -4,12 +4,12 @@
 using namespace std;
 
 class format_guard {
-    ostream& _os;
-    ios::fmtflags _f;
+    ostream& os;
+    ios::fmtflags f;
 
 public:
-    explicit format_guard(ostream& os = cout) : _os(os), _f(os.flags()) {}
-    ~format_guard() { _os.flags(_f); }
+    explicit format_guard(ostream& os = cout) : os(os), f(os.flags()) {}
+    ~format_guard() { os.flags(f); }
 };
 
 


### PR DESCRIPTION
The signature `ostream& operator<<(ostream &os, const scientific_type<T> &w)` suggests that all instances of `std::ostream` can be on the left hand side of `<<` even though `format_guard` only is able to reset `std::cout`. 
So when using `scientific_type` with `std::ofstream` or `std::ostringstream` one will get the surprising behaviour that those streams wont be reset.