### PR TITLE
some minor correction

### DIFF
--- a/Chapter09/auto_parallel.cpp
+++ b/Chapter09/auto_parallel.cpp
@@ -2,7 +2,6 @@
 #include <vector>
 #include <random>
 #include <algorithm>
-#include <algorith>
 #include <execution>
 
 using namespace std;


### PR DESCRIPTION
It seems like an obvious misprint and there is a small question for you ... I try to compile the file via g++-9 and I get 
--------------------------------------------------------------------------------------------------------------------
g++-9 -std=c++17 -o auto_parallel auto_parallel.cpp 
In file included from /usr/include/c++/9/pstl/parallel_backend.h:14,
                 from /usr/include/c++/9/pstl/algorithm_impl.h:25,
                 from /usr/include/c++/9/pstl/glue_execution_defs.h:52,
                 from /usr/include/c++/9/execution:32,
                 from auto_parallel.cpp:6:
/usr/include/c++/9/pstl/parallel_backend_tbb.h:19:10: fatal error: tbb/blocked_range.h: No such file or directory
   19 | #include <tbb/blocked_range.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
------------------------------------------------------------------------------------------------------------------

Should I install tbb to use STL parallelism or is it due to some install problems?